### PR TITLE
Fix debug details for iOS on Mac and Catalyst

### DIFF
--- a/Sources/AboutKit/Models/AboutKit.swift
+++ b/Sources/AboutKit/Models/AboutKit.swift
@@ -17,21 +17,7 @@ struct AboutKit {
 
     private init() {}
 
-    #if os(iOS) || os(visionOS)
-    /// A `String` containing debug details about the current app.
-    static let debugDetails: String = {
-        let versionNumber = Bundle.main.versionNumber
-        let buildNumber = Bundle.main.buildNumber
-        let versionDetails = "App Version: \(versionNumber) (\(buildNumber))"
-
-        let osDetails = "OS Version: \(UIDevice.current.systemVersion)"
-        let deviceDetails = "Device: \(UIDevice.current.deviceType)"
-        let environmentDetails = "Environment: \(Bundle.main.userType.title)"
-
-        return "\n\n\nDEBUG DETAILS\n\n\(versionDetails)\n\(osDetails)\n\(deviceDetails)\n\(environmentDetails)"
-    }()
-
-    #elseif os(macOS)
+    #if os(macOS) || targetEnvironment(macCatalyst)
 
     /// Returns a `String` containing the identifier of the current device, e.g. MacBook Pro 13,1
     private static let deviceType: String = {
@@ -63,5 +49,21 @@ struct AboutKit {
 
         return "\n\n\nDEBUG DETAILS\n\n\(versionDetails)\n\(osDetails)\n\(deviceDetails)\n\(environmentDetails)"
     }()
+
+    #elseif os(iOS) || os(visionOS)
+
+    /// A `String` containing debug details about the current app.
+    static let debugDetails: String = {
+        let versionNumber = Bundle.main.versionNumber
+        let buildNumber = Bundle.main.buildNumber
+        let versionDetails = "App Version: \(versionNumber) (\(buildNumber))"
+
+        let osDetails = "OS Version: \(ProcessInfo.processInfo.operatingSystemVersionString)"
+        let deviceDetails = "Device: \(ProcessInfo().isiOSAppOnMac ? "Mac" : UIDevice.current.deviceType)"
+        let environmentDetails = "Environment: \(Bundle.main.userType.title)"
+
+        return "\n\n\nDEBUG DETAILS\n\n\(versionDetails)\n\(osDetails)\n\(deviceDetails)\n\(environmentDetails)"
+    }()
+
     #endif
 }

--- a/Sources/AboutKit/Models/AboutKit.swift
+++ b/Sources/AboutKit/Models/AboutKit.swift
@@ -19,7 +19,7 @@ struct AboutKit {
 
     #if os(macOS) || targetEnvironment(macCatalyst)
 
-    /// Returns a `String` containing the identifier of the current device, e.g. MacBook Pro 13,1
+    /// Returns a `String` containing the identifier of the current device, e.g. MacBookPro13,1
     private static let deviceType: String = {
         let service = IOServiceGetMatchingService(
             kIOMainPortDefault,
@@ -52,6 +52,20 @@ struct AboutKit {
 
     #elseif os(iOS) || os(visionOS)
 
+    /// Returns a `String` containing the identifier of the current device, e.g. iPhone17,1
+    private static let deviceType: String = {
+        if ProcessInfo().isiOSAppOnMac {
+            var size = 0
+            let key = "hw.model"
+            sysctlbyname(key, nil, &size, nil, 0)
+            var value = [CChar](repeating: 0,  count: size)
+            sysctlbyname(key, &value, &size, nil, 0)
+            return String(cString: value, encoding: .utf8) ?? "Mac"
+        } else {
+            return UIDevice.current.deviceType
+        }
+    }()
+
     /// A `String` containing debug details about the current app.
     static let debugDetails: String = {
         let versionNumber = Bundle.main.versionNumber
@@ -59,7 +73,7 @@ struct AboutKit {
         let versionDetails = "App Version: \(versionNumber) (\(buildNumber))"
 
         let osDetails = "OS Version: \(ProcessInfo.processInfo.operatingSystemVersionString)"
-        let deviceDetails = "Device: \(ProcessInfo().isiOSAppOnMac ? "Mac" : UIDevice.current.deviceType)"
+        let deviceDetails = "Device: \(deviceType)"
         let environmentDetails = "Environment: \(Bundle.main.userType.title)"
 
         return "\n\n\nDEBUG DETAILS\n\n\(versionDetails)\n\(osDetails)\n\(deviceDetails)\n\(environmentDetails)"


### PR DESCRIPTION
This PR fixes the debug details for Mac Catalyst apps as well as iOS apps on Mac.

For iOS apps on Mac, the device model would return `iPad8,6`. It now returns the correct Mac model.

I also now use `ProcessInfo.processInfo.operatingSystemVersionString` for the iOS, visionOS part of the code too as the build number is helpful (to determine beta versions for example).

Mac Catalyst apps would show `arm64` as the device model, which has now been fixed.

Sample output:

```
App Version: 2.1.3 (29)
OS Version: Version 15.2 (Build 24C5079e)
Device: MacBookPro18,3
Environment: Debug
```